### PR TITLE
feat: add support for g1 torso imu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,7 @@
 ### 1.0.3 [IMPORTANT FIX]
 - Fix control delay, send command immediately after step.
     - this bug could lead to jittering and stability issue, see https://github.com/GDDG08/RoboJuDo/issues/2
+
+### 1.0.4
+- Add torso (secondary) IMU subscription, exposed via `RobotState.torso_imu_state`. see https://github.com/HansZ8/unitree_cpp/issues/5
+    - Opt-in via `enable_torso_imu` / `torso_imu_topic` (default `rt/secondary_imu`).

--- a/README.md
+++ b/README.md
@@ -78,7 +78,10 @@ This project supports:
 
 **1.0.3 [IMPORTANT FIX]**
 - Fix control delay, send command immediately after step.
-    - this bug could lead to jittering and stability issue, see https://github.com/GDDG08/RoboJuDo/issues/2
+    - this bug could lead to jittering and stability issue, see [#2](https://github.com/HansZ8/unitree_cpp/issues/2).
+
+**1.0.4**
+- Add torso (secondary) IMU data for G1, exposed via `RobotState.torso_imu_state`. see [#5](https://github.com/HansZ8/unitree_cpp/issues/5).
 
 
 ## License

--- a/example/config.py
+++ b/example/config.py
@@ -20,6 +20,9 @@ class UnitreeConfig(Config):
     enable_odometry: bool = True
     sport_state_topic: str = "rt/odommodestate"
 
+    enable_torso_imu: bool = True
+    torso_imu_topic: str = "rt/secondary_imu"
+
 # Config for G1 robot
 class RobotConfig(Config):
     unitree: UnitreeConfig = UnitreeConfig()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "unitree_cpp"
-version = "1.0.3"
+version = "1.0.4"
 description = "Pybind11 binding for UnitreeController with Unitree SDK"
 authors = [{ name = "GDDG08", email = "GDDG80@outlook.com" }]
 license = { text = "CC-BY-4.0" }

--- a/src/py_binding.cpp
+++ b/src/py_binding.cpp
@@ -18,6 +18,8 @@ void bind_UnitreeConfig(py::module_& m) {
         .def_readwrite("lowstate_topic", &UnitreeConfig::lowstate_topic)
         .def_readwrite("enable_odometry", &UnitreeConfig::enable_odometry)
         .def_readwrite("sport_state_topic", &UnitreeConfig::sport_state_topic)
+        .def_readwrite("enable_torso_imu", &UnitreeConfig::enable_torso_imu)
+        .def_readwrite("torso_imu_topic", &UnitreeConfig::torso_imu_topic)
         .def_readwrite("stiffness", &UnitreeConfig::stiffness)
         .def_readwrite("damping", &UnitreeConfig::damping)
         .def_readwrite("num_dofs", &UnitreeConfig::num_dofs);
@@ -42,6 +44,7 @@ void bind_RobotState(py::module_& m) {
         .def_readwrite("tick", &RobotState::tick)
         .def_readwrite("motor_state", &RobotState::motor_state)
         .def_readwrite("imu_state", &RobotState::imu_state)
+        .def_readwrite("torso_imu_state", &RobotState::torso_imu_state)
         // .def_readwrite("wireless_remote", &RobotState::wireless_remote);
         .def_property(
             "wireless_remote",
@@ -76,6 +79,12 @@ void bind_UnitreeController(py::module_& m) {
             cfg.lowstate_topic = cfg_dict["lowstate_topic"].cast<std::string>();
             cfg.sport_state_topic = cfg_dict["sport_state_topic"].cast<std::string>();
             cfg.enable_odometry = cfg_dict["enable_odometry"].cast<bool>();
+            cfg.enable_torso_imu = cfg_dict.contains("enable_torso_imu")
+                                       ? cfg_dict["enable_torso_imu"].cast<bool>()
+                                       : true;
+            cfg.torso_imu_topic = cfg_dict.contains("torso_imu_topic")
+                                      ? cfg_dict["torso_imu_topic"].cast<std::string>()
+                                      : std::string("rt/secondary_imu");
             cfg.stiffness = cfg_dict["stiffness"].cast<std::vector<double>>();
             cfg.damping = cfg_dict["damping"].cast<std::vector<double>>();
             cfg.num_dofs = cfg_dict["num_dofs"].cast<unsigned short>();

--- a/src/unitree_controller.cpp
+++ b/src/unitree_controller.cpp
@@ -64,8 +64,14 @@ UnitreeController::UnitreeController(const UnitreeConfig& cfg)
     lowcmd_publisher_->InitChannel();
     lowstate_subscriber_.reset(new ChannelSubscriber<LowState_>(cfg_.lowstate_topic));
     lowstate_subscriber_->InitChannel(std::bind(&UnitreeController::LowStateHandler, this, std::placeholders::_1), 1);
-    // imutorso_subscriber_.reset(new ChannelSubscriber<IMUState_>(HG_IMU_TORSO));
-    // imutorso_subscriber_->InitChannel(std::bind(&UnitreeController::imuTorsoHandler, this, std::placeholders::_1), 1);
+
+    if (cfg_.enable_torso_imu) {
+        std::cout << "Torso IMU enabled, subscribing to topic: " << cfg_.torso_imu_topic << std::endl;
+        torso_imu_subscriber_.reset(new ChannelSubscriber<IMUState_>(cfg_.torso_imu_topic));
+        torso_imu_subscriber_->InitChannel(std::bind(&UnitreeController::TorsoImuStateHandler, this, std::placeholders::_1), 1);
+    } else {
+        std::cout << "Torso IMU disabled." << std::endl;
+    }
 
     if (cfg_.enable_odometry) {
         std::cout << "Odometry enabled, subscribing to sport state topic: " << cfg_.sport_state_topic << std::endl;
@@ -157,6 +163,14 @@ void UnitreeController::LowStateHandler(const void* message) {
     memcpy(&robot_state_tmp.wireless_remote, &low_state.wireless_remote()[0], 40);
     // std::cout << "imu rpy: " << imu_tmp.rpy[0] << ", " << imu_tmp.rpy[1] << ", " << imu_tmp.rpy[2] << std::endl;
 
+    // attach the most recent torso IMU sample (if available); otherwise leave default identity
+    if (cfg_.enable_torso_imu) {
+        const std::shared_ptr<const ImuState> torso_imu = torso_imu_state_buffer_.GetData();
+        if (torso_imu) {
+            robot_state_tmp.torso_imu_state = *torso_imu;
+        }
+    }
+
     robot_state_buffer_.SetData(robot_state_tmp);
 
     // update mode machine
@@ -165,6 +179,17 @@ void UnitreeController::LowStateHandler(const void* message) {
             std::cout << "G1 type: " << unsigned(low_state.mode_machine()) << std::endl;
         mode_machine_ = low_state.mode_machine();
     }
+}
+
+void UnitreeController::TorsoImuStateHandler(const void* message) {
+    const IMUState_& dds_imu = *(const IMUState_*)message;
+
+    ImuState imu_tmp;
+    imu_tmp.rpy = dds_imu.rpy();
+    imu_tmp.gyroscope = dds_imu.gyroscope();
+    imu_tmp.quaternion = dds_imu.quaternion();
+    imu_tmp.accelerometer = dds_imu.accelerometer();
+    torso_imu_state_buffer_.SetData(imu_tmp);
 }
 
 void UnitreeController::SportStateHandler(const void* message) {
@@ -351,6 +376,8 @@ int main(int argc, char const* argv[]) {
     config.lowstate_topic = "rt/lowstate";
     config.enable_odometry = false;
     config.sport_state_topic = "rt/odommodestate";
+    config.enable_torso_imu = true;
+    config.torso_imu_topic = "rt/secondary_imu";
     config.stiffness = {1.0, 1.0, 1.0};  // Example stiffness values
     config.damping = {0.1, 0.1, 0.1};    // Example damping values
     config.num_dofs = 3;                 // Example number of DOFs

--- a/src/unitree_controller.cpp
+++ b/src/unitree_controller.cpp
@@ -67,7 +67,7 @@ UnitreeController::UnitreeController(const UnitreeConfig& cfg)
 
     if (cfg_.enable_torso_imu) {
         std::cout << "Torso IMU enabled, subscribing to topic: " << cfg_.torso_imu_topic << std::endl;
-        torso_imu_subscriber_.reset(new ChannelSubscriber<IMUState_>(cfg_.torso_imu_topic));
+        torso_imu_subscriber_.reset(new ChannelSubscriber<unitree_hg::msg::dds_::IMUState_>(cfg_.torso_imu_topic));
         torso_imu_subscriber_->InitChannel(std::bind(&UnitreeController::TorsoImuStateHandler, this, std::placeholders::_1), 1);
     } else {
         std::cout << "Torso IMU disabled." << std::endl;
@@ -182,6 +182,7 @@ void UnitreeController::LowStateHandler(const void* message) {
 }
 
 void UnitreeController::TorsoImuStateHandler(const void* message) {
+    using unitree_hg::msg::dds_::IMUState_;
     const IMUState_& dds_imu = *(const IMUState_*)message;
 
     ImuState imu_tmp;

--- a/src/unitree_controller.hpp
+++ b/src/unitree_controller.hpp
@@ -190,7 +190,7 @@ class UnitreeController {
 
     ChannelSubscriberPtr<LowState_> lowstate_subscriber_;
     ChannelPublisherPtr<LowCmd_> lowcmd_publisher_;
-    ChannelSubscriberPtr<IMUState_> torso_imu_subscriber_;
+    ChannelSubscriberPtr<unitree_hg::msg::dds_::IMUState_> torso_imu_subscriber_;
     ThreadPtr command_writer_ptr_;
 
     ChannelSubscriberPtr<unitree_go::msg::dds_::SportModeState_> estimate_state_subscriber;

--- a/src/unitree_controller.hpp
+++ b/src/unitree_controller.hpp
@@ -107,7 +107,8 @@ struct ImuState {
 struct RobotState {
     uint32_t tick;
     MotorState motor_state;
-    ImuState imu_state;
+    ImuState imu_state;        // pelvis / base IMU from LowState
+    ImuState torso_imu_state;  // optional torso IMU from rt/secondary_imu (G1)
     uint8_t wireless_remote[40];
 
     RobotState(size_t num_motors) : tick(0),
@@ -143,6 +144,9 @@ struct UnitreeConfig {
 
     bool enable_odometry;
     std::string sport_state_topic;
+
+    bool enable_torso_imu;       // subscribe to torso (secondary) IMU
+    std::string torso_imu_topic; // default "rt/secondary_imu" (G1)
 
     std::vector<double> stiffness;
     std::vector<double> damping;
@@ -186,7 +190,7 @@ class UnitreeController {
 
     ChannelSubscriberPtr<LowState_> lowstate_subscriber_;
     ChannelPublisherPtr<LowCmd_> lowcmd_publisher_;
-    // ChannelSubscriberPtr<IMUState_> imutorso_subscriber_;
+    ChannelSubscriberPtr<IMUState_> torso_imu_subscriber_;
     ThreadPtr command_writer_ptr_;
 
     ChannelSubscriberPtr<unitree_go::msg::dds_::SportModeState_> estimate_state_subscriber;
@@ -201,6 +205,10 @@ class UnitreeController {
 
     void LowStateHandler(const void* message);
     void SportStateHandler(const void* message);
+    void TorsoImuStateHandler(const void* message);
     void LowCommandWriter();
     void HandCommandWriter();
+
+    // latest torso IMU snapshot, copied into RobotState in get_robot_state()
+    DataBuffer<ImuState> torso_imu_state_buffer_;
 };


### PR DESCRIPTION
Add subscription to the G1 torso (secondary) IMUState. 
The sensor data is accessible via `RobotState.torso_imu_state`. 

This feature can be enabled through the `enable_torso_imu` configuration option, with a default topic of `rt/secondary_imu`. 

See #5.