### PR TITLE
feat: add bundled header-only dummy SDK for hardware-free builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Add torso (secondary) IMU subscription, exposed via `RobotState.torso_imu_state`. see https://github.com/HansZ8/unitree_cpp/issues/5
     - Opt-in via `enable_torso_imu` / `torso_imu_topic` (default `rt/secondary_imu`).
 
-### Unreleased
+### dummy_sdk (opt-in)
 - Add a bundled header-only dummy `unitree_sdk2` (`dummy_sdk/`) so the module can
   build and import on machines without the real SDK (e.g. macOS). Opt-in via
   `-DUSE_DUMMY_SDK=ON`; a normal build still requires the real SDK and fails

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,12 @@
 ### 1.0.4
 - Add torso (secondary) IMU subscription, exposed via `RobotState.torso_imu_state`. see https://github.com/HansZ8/unitree_cpp/issues/5
     - Opt-in via `enable_torso_imu` / `torso_imu_topic` (default `rt/secondary_imu`).
+
+### Unreleased
+- Add a bundled header-only dummy `unitree_sdk2` (`dummy_sdk/`) so the module can
+  build and import on machines without the real SDK (e.g. macOS). Opt-in via
+  `-DUSE_DUMMY_SDK=ON`; a normal build still requires the real SDK and fails
+  loudly if it is missing, never silently falling back. The dummy simulates
+  inbound data (stationary robot, identity base IMU, tilted torso IMU, zero
+  odometry) so `self_check()` passes and the pipeline runs. Test only — never
+  deploy. See the TESTING guide in the README.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,26 +12,52 @@ find_package(pybind11 CONFIG REQUIRED)
 find_package(pybind11 REQUIRED)
 find_package(Threads REQUIRED)
 
-find_library(UNITREE_SDK2_LIB NAMES unitree_sdk2 PATHS /usr/local/lib /usr/lib)
-find_path(UNITREE_SDK2_INCLUDE NAMES unitree/robot/channel/channel_factory.hpp PATHS /usr/local/include /usr/include)
+# ---------------------------------------------------------------------------
+# Unitree SDK2 backend.
+#
+# Default: link the installed unitree_sdk2 + CycloneDDS (real robot).
+#
+# TEST ONLY: pass -DUSE_DUMMY_SDK=ON to build against the bundled header-only
+# dummy SDK (dummy_sdk/), which needs no hardware or DDS and feeds simulated
+# data. This is opt-in on purpose — a normal install without the SDK fails
+# loudly rather than silently producing a non-functional module. See README.
+# ---------------------------------------------------------------------------
+option(USE_DUMMY_SDK "TEST ONLY: build against the bundled dummy unitree_sdk2 (no hardware/DDS)" OFF)
 
-find_library(DDSC_LIB NAMES ddsc PATHS /usr/local/lib /usr/lib)
-find_library(DDSCXX_LIB NAMES ddscxx PATHS /usr/local/lib /usr/lib)
-find_path(DDSCXX_ROOT_INCLUDE dds/dds.hpp PATHS /usr/local/include/ddscxx /usr/include)
+if(USE_DUMMY_SDK)
+  message(WARNING "unitree_cpp: building against the bundled DUMMY SDK "
+                  "(TEST ONLY — no hardware, simulated data).")
+  set(SDK_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/dummy_sdk/include)
+  set(SDK_LIBRARIES "")
+else()
+  find_library(UNITREE_SDK2_LIB NAMES unitree_sdk2 PATHS /usr/local/lib /usr/lib)
+  find_path(UNITREE_SDK2_INCLUDE NAMES unitree/robot/channel/channel_factory.hpp PATHS /usr/local/include /usr/include)
+  find_library(DDSC_LIB NAMES ddsc PATHS /usr/local/lib /usr/lib)
+  find_library(DDSCXX_LIB NAMES ddscxx PATHS /usr/local/lib /usr/lib)
+  find_path(DDSCXX_ROOT_INCLUDE dds/dds.hpp PATHS /usr/local/include/ddscxx /usr/include)
 
-if(NOT UNITREE_SDK2_LIB OR NOT UNITREE_SDK2_INCLUDE)
-  message(FATAL_ERROR "Cannot find installed unitree_sdk2 library or headers in /usr/local")
+  if(NOT UNITREE_SDK2_LIB OR NOT UNITREE_SDK2_INCLUDE)
+    message(FATAL_ERROR "Cannot find installed unitree_sdk2 library or headers in /usr/local. "
+                        "For a hardware-free test build, pass -DUSE_DUMMY_SDK=ON.")
+  endif()
+
+  if(NOT DDSC_LIB OR NOT DDSCXX_LIB OR NOT DDSCXX_ROOT_INCLUDE)
+    message(FATAL_ERROR "Cannot find ddscxx or headers")
+  endif()
+
+  message(STATUS "Found unitree_sdk2 lib: ${UNITREE_SDK2_LIB}")
+  message(STATUS "Found unitree_sdk2 include: ${UNITREE_SDK2_INCLUDE}")
+  message(STATUS "Found ddsc lib: ${DDSC_LIB}")
+  message(STATUS "Found ddscxx lib: ${DDSCXX_LIB}")
+  message(STATUS "Found ddscxx root include: ${DDSCXX_ROOT_INCLUDE}")
+
+  # `dl` is provided by libSystem on Apple, so only link it on other platforms.
+  set(SDK_INCLUDE_DIRS ${UNITREE_SDK2_INCLUDE} ${DDSCXX_ROOT_INCLUDE})
+  set(SDK_LIBRARIES ${UNITREE_SDK2_LIB} ${DDSC_LIB} ${DDSCXX_LIB})
+  if(NOT APPLE)
+    list(APPEND SDK_LIBRARIES dl)
+  endif()
 endif()
-
-if(NOT DDSC_LIB OR NOT DDSCXX_LIB OR NOT DDSCXX_ROOT_INCLUDE)
-  message(FATAL_ERROR "Cannot find ddscxx or headers")
-endif()
-
-message(STATUS "Found unitree_sdk2 lib: ${UNITREE_SDK2_LIB}")
-message(STATUS "Found unitree_sdk2 include: ${UNITREE_SDK2_INCLUDE}")
-message(STATUS "Found ddsc lib: ${DDSC_LIB}")
-message(STATUS "Found ddscxx lib: ${DDSCXX_LIB}")
-message(STATUS "Found ddscxx root include: ${DDSCXX_ROOT_INCLUDE}")
 
 # Add a library using FindPython's tooling (pybind11 also provides a helper like
 # this)
@@ -43,22 +69,23 @@ python_add_library(unitree_cpp MODULE
 
 
 target_include_directories(unitree_cpp PRIVATE
-  ${UNITREE_SDK2_INCLUDE}
-  ${DDSCXX_ROOT_INCLUDE}
+  ${SDK_INCLUDE_DIRS}
 )
 
 target_link_libraries(unitree_cpp PRIVATE
   pybind11::headers
-  ${UNITREE_SDK2_LIB}
-  ${DDSC_LIB}
-  ${DDSCXX_LIB}
-  dl
+  ${SDK_LIBRARIES}
   Threads::Threads
 )
 
 
 # This is passing in the version as a define just as an example
 target_compile_definitions(unitree_cpp PRIVATE VERSION_INFO=${PROJECT_VERSION})
+
+# Let the Python layer warn loudly that this is a simulated, test-only build.
+if(USE_DUMMY_SDK)
+  target_compile_definitions(unitree_cpp PRIVATE USE_DUMMY_SDK)
+endif()
 
 # The install directory is the output (wheel) directory
 install(TARGETS unitree_cpp DESTINATION unitree_cpp)
@@ -78,15 +105,11 @@ add_executable(debugcpp
 )
 
 target_include_directories(debugcpp PRIVATE
-  ${UNITREE_SDK2_INCLUDE}
-  ${DDSCXX_ROOT_INCLUDE}
+  ${SDK_INCLUDE_DIRS}
 )
 
 target_link_libraries(debugcpp PRIVATE
-  ${UNITREE_SDK2_LIB}
-  ${DDSC_LIB}
-  ${DDSCXX_LIB}
-  dl
+  ${SDK_LIBRARIES}
   Threads::Threads
 )
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,36 @@ This project supports:
 - Add torso (secondary) IMU data for G1, exposed via `RobotState.torso_imu_state`. see [#5](https://github.com/HansZ8/unitree_cpp/issues/5).
 
 
+## TESTING guide
+
+> **Debug / development only.** The dummy SDK has no hardware or DDS and serves
+> simulated data — never deploy a dummy build to a real robot.
+
+The real Unitree SDK2 + CycloneDDS cannot be installed on every machine (e.g.
+macOS dev laptops). For development and interface testing, a header-only **dummy
+SDK** is bundled under [`dummy_sdk/`](dummy_sdk/). It provides stand-ins for the
+SDK symbols so the extension builds and `import unitree_cpp` works without any
+hardware or DDS.
+
+To make the pipeline runnable, the dummy **simulates inbound data**: subscribers
+synthesize a stationary robot (zeroed joints, identity base IMU, a slightly
+tilted torso IMU, zero odometry) and deliver it to the controller's callbacks, so
+`self_check()` passes and `get_robot_state()` returns a populated state. Commands
+sent via publishers are simply dropped.
+
+The dummy is **opt-in**. A normal build links the real `unitree_sdk2` and fails
+loudly if it is not found, so a missing SDK is never silently replaced by a
+non-functional module. Enable the dummy explicitly:
+
+```bash
+pip install . --config-settings=cmake.define.USE_DUMMY_SDK=ON
+# or, with uv:
+uv pip install . --config-settings=cmake.define.USE_DUMMY_SDK=ON
+```
+
+A dummy build also emits a `RuntimeWarning` on `import unitree_cpp`, so it is
+never mistaken for a real one.
+
 ## License
 
 CC-BY-4.0

--- a/dummy_sdk/include/unitree/dummy_prelude.hpp
+++ b/dummy_sdk/include/unitree/dummy_prelude.hpp
@@ -1,0 +1,50 @@
+// Dummy unitree_sdk2 — shared prelude.
+//
+// This is a header-only, no-op stand-in for the real Unitree SDK2 + CycloneDDS,
+// used to build/import `unitree_cpp` on platforms where the real SDK cannot be
+// installed (e.g. macOS). It provides exactly the symbols `unitree_controller`
+// references — nothing connects to hardware, publishers drop writes and
+// subscribers never fire, so `self_check()` will report no data at runtime.
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <sys/types.h>  // uint
+#include <unistd.h>     // sleep
+
+// Generate a value-semantic field with const/non-const accessors, matching the
+// IDL message style `obj.field() = x` / `x = obj.field()` used by the SDK.
+// The type is variadic so that template types with commas (e.g. std::array<T, N>)
+// pass through as a single argument.
+#define UT_DUMMY_FIELD(name, ...)                       \
+    __VA_ARGS__ _##name{};                              \
+    __VA_ARGS__& name() { return _##name; }             \
+    const __VA_ARGS__& name() const { return _##name; }
+
+namespace unitree {
+namespace common {
+
+#ifndef UT_CPU_ID_NONE
+#define UT_CPU_ID_NONE (-1)
+#endif
+
+// Opaque recurrent-thread handle. The dummy never actually runs the callback.
+class Thread {
+   public:
+    virtual ~Thread() = default;
+};
+using ThreadPtr = std::shared_ptr<Thread>;
+
+template <typename... Args>
+inline ThreadPtr CreateRecurrentThreadEx(Args&&...) {
+    return std::make_shared<Thread>();
+}
+
+}  // namespace common
+}  // namespace unitree

--- a/dummy_sdk/include/unitree/dummy_simulator.hpp
+++ b/dummy_sdk/include/unitree/dummy_simulator.hpp
@@ -1,0 +1,84 @@
+// Dummy unitree_sdk2 — synthetic data simulation.
+//
+// Without real DDS there is no hardware to talk to, so the dummy subscribers
+// (see channel_subscriber.hpp) synthesize messages and hand them straight to the
+// controller's callbacks at subscription time. This populates the controller's
+// state buffers so `self_check()` passes and the pipeline runs on a machine
+// without the SDK (e.g. macOS): a stationary robot with zeroed joints, an
+// identity base IMU and a slightly tilted torso IMU.
+//
+// Delivery is synchronous (no background threads): every message is produced
+// while the controller is fully constructed and alive, which avoids the
+// use-after-free that a teardown-racing callback thread would hit.
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+#include <unitree/idl/go2/SportModeState_.hpp>
+#include <unitree/idl/hg/IMUState_.hpp>
+#include <unitree/idl/hg/LowState_.hpp>
+
+namespace unitree_dummy {
+
+// Mirror of the controller's Crc32Core (poly 0x04c11db7, init 0xFFFFFFFF) so a
+// synthesized LowState_ passes the controller's CRC check.
+inline uint32_t crc32(const uint32_t* ptr, uint32_t len) {
+    uint32_t crc = 0xFFFFFFFF;
+    const uint32_t poly = 0x04c11db7;
+    for (uint32_t i = 0; i < len; ++i) {
+        uint32_t xbit = 1u << 31;
+        uint32_t data = ptr[i];
+        for (uint32_t bit = 0; bit < 32; ++bit) {
+            if (crc & 0x80000000)
+                crc = (crc << 1) ^ poly;
+            else
+                crc <<= 1;
+            if (data & xbit)
+                crc ^= poly;
+            xbit >>= 1;
+        }
+    }
+    return crc;
+}
+
+// LowState_ aggregates the latest torso-IMU / sport buffers when it is handled,
+// so after those arrive we re-deliver LowState_ to refresh the assembled
+// RobotState. These hooks are registered by LowState_ subscribers and invoked by
+// other subscribers, all during controller construction. ChannelFactory::Init()
+// clears them so a freshly constructed controller never calls a stale hook.
+inline std::vector<std::function<void()>>& lowstate_refreshers() {
+    static std::vector<std::function<void()>> hooks;
+    return hooks;
+}
+
+inline void refresh_lowstate() {
+    for (auto& hook : lowstate_refreshers()) {
+        if (hook) {
+            hook();
+        }
+    }
+}
+
+}  // namespace unitree_dummy
+
+// Customization point used by the dummy subscriber. The generic version leaves
+// the default-constructed message untouched; overloads below fill plausible data.
+template <typename MSG>
+inline void dummy_fill(MSG&, uint32_t /*tick*/) {}
+
+inline void dummy_fill(unitree_hg::msg::dds_::LowState_& s, uint32_t tick) {
+    s.tick() = (tick == 0) ? 1u : tick;  // self_check rejects tick == 0
+    s.mode_machine() = 4;
+    s.imu_state().quaternion() = {1.0f, 0.0f, 0.0f, 0.0f};  // identity base IMU (w-first)
+    // motors and wireless_remote stay zero-initialized.
+    // crc is the final member of LowState_; CRC every preceding word.
+    s.crc() = unitree_dummy::crc32(reinterpret_cast<const uint32_t*>(&s), (sizeof(s) >> 2) - 1);
+}
+
+inline void dummy_fill(unitree_hg::msg::dds_::IMUState_& s, uint32_t /*tick*/) {
+    // ~5 deg pitch (w-first), distinct from identity so the consumer treats it as
+    // a real torso-IMU sample rather than "no data yet".
+    s.quaternion() = {0.99905f, 0.0f, 0.04362f, 0.0f};
+}

--- a/dummy_sdk/include/unitree/idl/go2/SportModeState_.hpp
+++ b/dummy_sdk/include/unitree/idl/go2/SportModeState_.hpp
@@ -1,0 +1,17 @@
+// Dummy unitree_sdk2 — sport-mode (odometry) state message.
+#pragma once
+
+#include <unitree/dummy_prelude.hpp>
+
+namespace unitree_go {
+namespace msg {
+namespace dds_ {
+
+struct SportModeState_ {
+    UT_DUMMY_FIELD(position, std::array<float, 3>)
+    UT_DUMMY_FIELD(velocity, std::array<float, 3>)
+};
+
+}  // namespace dds_
+}  // namespace msg
+}  // namespace unitree_go

--- a/dummy_sdk/include/unitree/idl/hg/HandCmd_.hpp
+++ b/dummy_sdk/include/unitree/idl/hg/HandCmd_.hpp
@@ -1,0 +1,18 @@
+// Dummy unitree_sdk2 — dexterous-hand command message.
+#pragma once
+
+#include <unitree/dummy_prelude.hpp>
+#include <unitree/idl/hg/_msg_common.hpp>
+
+namespace unitree_hg {
+namespace msg {
+namespace dds_ {
+
+struct HandCmd_ {
+    // accessed via motor_cmd().resize(n) and motor_cmd().at(i)
+    UT_DUMMY_FIELD(motor_cmd, std::vector<MotorCmd_>)
+};
+
+}  // namespace dds_
+}  // namespace msg
+}  // namespace unitree_hg

--- a/dummy_sdk/include/unitree/idl/hg/HandState_.hpp
+++ b/dummy_sdk/include/unitree/idl/hg/HandState_.hpp
@@ -1,0 +1,19 @@
+// Dummy unitree_sdk2 — dexterous-hand state message (included but unused here).
+#pragma once
+
+#include <unitree/dummy_prelude.hpp>
+#include <unitree/idl/hg/IMUState_.hpp>
+#include <unitree/idl/hg/_msg_common.hpp>
+
+namespace unitree_hg {
+namespace msg {
+namespace dds_ {
+
+struct HandState_ {
+    UT_DUMMY_FIELD(motor_state, std::vector<MotorState_>)
+    UT_DUMMY_FIELD(imu_state, IMUState_)
+};
+
+}  // namespace dds_
+}  // namespace msg
+}  // namespace unitree_hg

--- a/dummy_sdk/include/unitree/idl/hg/IMUState_.hpp
+++ b/dummy_sdk/include/unitree/idl/hg/IMUState_.hpp
@@ -1,0 +1,19 @@
+// Dummy unitree_sdk2 — IMU state message.
+#pragma once
+
+#include <unitree/dummy_prelude.hpp>
+
+namespace unitree_hg {
+namespace msg {
+namespace dds_ {
+
+struct IMUState_ {
+    UT_DUMMY_FIELD(quaternion, std::array<float, 4>)
+    UT_DUMMY_FIELD(gyroscope, std::array<float, 3>)
+    UT_DUMMY_FIELD(accelerometer, std::array<float, 3>)
+    UT_DUMMY_FIELD(rpy, std::array<float, 3>)
+};
+
+}  // namespace dds_
+}  // namespace msg
+}  // namespace unitree_hg

--- a/dummy_sdk/include/unitree/idl/hg/LowCmd_.hpp
+++ b/dummy_sdk/include/unitree/idl/hg/LowCmd_.hpp
@@ -1,0 +1,20 @@
+// Dummy unitree_sdk2 — low-level command message.
+#pragma once
+
+#include <unitree/dummy_prelude.hpp>
+#include <unitree/idl/hg/_msg_common.hpp>
+
+namespace unitree_hg {
+namespace msg {
+namespace dds_ {
+
+struct LowCmd_ {
+    UT_DUMMY_FIELD(mode_pr, uint8_t)
+    UT_DUMMY_FIELD(mode_machine, uint8_t)
+    UT_DUMMY_FIELD(crc, uint32_t)
+    UT_DUMMY_FIELD(motor_cmd, std::array<MotorCmd_, 64>)  // accessed via motor_cmd().at(i)
+};
+
+}  // namespace dds_
+}  // namespace msg
+}  // namespace unitree_hg

--- a/dummy_sdk/include/unitree/idl/hg/LowState_.hpp
+++ b/dummy_sdk/include/unitree/idl/hg/LowState_.hpp
@@ -1,0 +1,25 @@
+// Dummy unitree_sdk2 — low-level robot state message.
+#pragma once
+
+#include <unitree/dummy_prelude.hpp>
+#include <unitree/idl/hg/IMUState_.hpp>
+#include <unitree/idl/hg/_msg_common.hpp>
+
+namespace unitree_hg {
+namespace msg {
+namespace dds_ {
+
+struct LowState_ {
+    UT_DUMMY_FIELD(tick, uint32_t)
+    UT_DUMMY_FIELD(mode_machine, uint8_t)
+    UT_DUMMY_FIELD(motor_state, std::array<MotorState_, 64>)  // indexed: motor_state()[i]
+    UT_DUMMY_FIELD(imu_state, IMUState_)
+    UT_DUMMY_FIELD(wireless_remote, std::array<uint8_t, 40>)
+    // `crc` MUST stay last: the controller CRCs all words except the final one,
+    // so the dummy data path can fill a matching CRC (see dummy_simulator.hpp).
+    UT_DUMMY_FIELD(crc, uint32_t)
+};
+
+}  // namespace dds_
+}  // namespace msg
+}  // namespace unitree_hg

--- a/dummy_sdk/include/unitree/idl/hg/_msg_common.hpp
+++ b/dummy_sdk/include/unitree/idl/hg/_msg_common.hpp
@@ -1,0 +1,28 @@
+// Dummy unitree_sdk2 — shared per-motor message records.
+#pragma once
+
+#include <unitree/dummy_prelude.hpp>
+
+namespace unitree_hg {
+namespace msg {
+namespace dds_ {
+
+struct MotorState_ {
+    UT_DUMMY_FIELD(q, float)
+    UT_DUMMY_FIELD(dq, float)
+    UT_DUMMY_FIELD(tau_est, float)
+    UT_DUMMY_FIELD(motorstate, uint8_t)
+};
+
+struct MotorCmd_ {
+    UT_DUMMY_FIELD(mode, uint8_t)
+    UT_DUMMY_FIELD(q, float)
+    UT_DUMMY_FIELD(dq, float)
+    UT_DUMMY_FIELD(kp, float)
+    UT_DUMMY_FIELD(kd, float)
+    UT_DUMMY_FIELD(tau, float)
+};
+
+}  // namespace dds_
+}  // namespace msg
+}  // namespace unitree_hg

--- a/dummy_sdk/include/unitree/robot/b2/motion_switcher/motion_switcher_client.hpp
+++ b/dummy_sdk/include/unitree/robot/b2/motion_switcher/motion_switcher_client.hpp
@@ -1,0 +1,21 @@
+// Dummy unitree_sdk2 — motion-switcher client (no service to talk to).
+#pragma once
+
+#include <unitree/dummy_prelude.hpp>
+
+namespace unitree {
+namespace robot {
+namespace b2 {
+
+class MotionSwitcherClient {
+   public:
+    void SetTimeout(float) {}
+    void Init() {}
+    // Leaves `name` empty so the controller's release loop exits immediately.
+    int32_t CheckMode(std::string& /*form*/, std::string& /*name*/) { return 0; }
+    int32_t ReleaseMode() { return 0; }
+};
+
+}  // namespace b2
+}  // namespace robot
+}  // namespace unitree

--- a/dummy_sdk/include/unitree/robot/channel/channel_factory.hpp
+++ b/dummy_sdk/include/unitree/robot/channel/channel_factory.hpp
@@ -1,0 +1,22 @@
+// Dummy unitree_sdk2 — DDS channel factory (no-op).
+#pragma once
+
+#include <unitree/dummy_prelude.hpp>
+#include <unitree/dummy_simulator.hpp>
+
+namespace unitree {
+namespace robot {
+
+class ChannelFactory {
+   public:
+    static ChannelFactory* Instance() {
+        static ChannelFactory instance;
+        return &instance;
+    }
+    // Called once at the start of controller construction; drop any refresh hooks
+    // left over from a previously destroyed controller before new ones register.
+    void Init(int, const std::string& = "") { unitree_dummy::lowstate_refreshers().clear(); }
+};
+
+}  // namespace robot
+}  // namespace unitree

--- a/dummy_sdk/include/unitree/robot/channel/channel_publisher.hpp
+++ b/dummy_sdk/include/unitree/robot/channel/channel_publisher.hpp
@@ -1,0 +1,25 @@
+// Dummy unitree_sdk2 — DDS publisher (drops every write).
+#pragma once
+
+#include <unitree/dummy_prelude.hpp>
+#include <unitree/robot/channel/channel_factory.hpp>
+
+namespace unitree {
+namespace robot {
+
+template <typename MSG>
+class ChannelPublisher {
+   public:
+    explicit ChannelPublisher(const std::string& topic) : topic_(topic) {}
+    void InitChannel() {}
+    void Write(const MSG&) {}
+
+   private:
+    std::string topic_;
+};
+
+template <typename MSG>
+using ChannelPublisherPtr = std::shared_ptr<ChannelPublisher<MSG>>;
+
+}  // namespace robot
+}  // namespace unitree

--- a/dummy_sdk/include/unitree/robot/channel/channel_subscriber.hpp
+++ b/dummy_sdk/include/unitree/robot/channel/channel_subscriber.hpp
@@ -1,0 +1,62 @@
+// Dummy unitree_sdk2 — DDS subscriber.
+//
+// Real DDS delivers messages from the network on a background thread. With no
+// network available, this dummy synthesizes messages (see dummy_simulator.hpp)
+// and delivers them synchronously to the registered callback at subscription
+// time, so the controller observes a populated (stationary) robot state without
+// any background thread that could outlive the controller.
+#pragma once
+
+#include <type_traits>
+
+#include <unitree/dummy_prelude.hpp>
+#include <unitree/dummy_simulator.hpp>
+#include <unitree/robot/channel/channel_factory.hpp>
+
+namespace unitree {
+namespace robot {
+
+template <typename MSG>
+class ChannelSubscriber {
+   public:
+    explicit ChannelSubscriber(const std::string& topic) : topic_(topic) {}
+
+    // Accepts the std::bind(...) handler used by the controller and immediately
+    // feeds it synthetic data.
+    template <typename Handler>
+    void InitChannel(Handler&& handler, int = 0) {
+        handler_ = std::forward<Handler>(handler);
+
+        if constexpr (std::is_same_v<MSG, unitree_hg::msg::dds_::LowState_>) {
+            // LowState_ assembles RobotState from dependent buffers, so register a
+            // refresh hook (re-invoked once torso/sport data arrives) and deliver now.
+            auto deliver = [this]() { this->Deliver(); };
+            deliver();
+            unitree_dummy::lowstate_refreshers().push_back(deliver);
+        } else {
+            // torso IMU / sport state: deliver, then refresh LowState so the
+            // assembled RobotState includes this freshly-populated buffer.
+            Deliver();
+            unitree_dummy::refresh_lowstate();
+        }
+    }
+
+   private:
+    void Deliver() {
+        MSG msg{};
+        dummy_fill(msg, ++tick_);
+        if (handler_) {
+            handler_(static_cast<const void*>(&msg));
+        }
+    }
+
+    std::string topic_;
+    std::function<void(const void*)> handler_;
+    uint32_t tick_ = 0;
+};
+
+template <typename MSG>
+using ChannelSubscriberPtr = std::shared_ptr<ChannelSubscriber<MSG>>;
+
+}  // namespace robot
+}  // namespace unitree

--- a/src/py_binding.cpp
+++ b/src/py_binding.cpp
@@ -114,6 +114,13 @@ void bind_UnitreeController(py::module_& m) {
 PYBIND11_MODULE(unitree_cpp, m) {
     m.doc() = "pybind11 bindings for UnitreeController";
 
+    // True when built against the bundled dummy SDK (test only, simulated data).
+#ifdef USE_DUMMY_SDK
+    m.attr("__is_dummy__") = true;
+#else
+    m.attr("__is_dummy__") = false;
+#endif
+
     // bind_ControlMode(m);
     bind_UnitreeConfig(m);
     bind_RobotState(m);

--- a/src/unitree_cpp/__init__.py
+++ b/src/unitree_cpp/__init__.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import List
 
 from .unitree_cpp import UnitreeController
@@ -5,6 +6,21 @@ from .unitree_cpp import ImuState as _ImuState
 from .unitree_cpp import MotorState as _MotorState
 from .unitree_cpp import RobotState as _RobotState
 from .unitree_cpp import SportState as _SportState
+
+try:
+    from .unitree_cpp import __is_dummy__ as _IS_DUMMY
+except ImportError:  # older builds without the flag
+    _IS_DUMMY = False
+
+if _IS_DUMMY:
+    # Built against the dummy SDK (USE_DUMMY_SDK=ON): no hardware/DDS, simulated
+    # data. Warn loudly so a test build is never mistaken for a real one.
+    warnings.warn(
+        "unitree_cpp was built against the DUMMY SDK: no real hardware or DDS, "
+        "all sensor data is simulated. For testing only — never deploy to a robot.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
 
 
 class MotorState(_MotorState):


### PR DESCRIPTION
Add dummy_sdk/, a header-only stand-in for unitree_sdk2 + CycloneDDS so the extension builds and `import unitree_cpp` works on machines without the real SDK (e.g. macOS). It simulates inbound data (stationary robot, identity base IMU, slightly tilted torso IMU, zero odometry) so self_check() passes and the pipeline runs; outbound commands are dropped.

The dummy is strictly opt-in via -DUSE_DUMMY_SDK=ON. A normal build still requires the real SDK and fails loudly (FATAL_ERROR) if it is missing — it is never auto-selected, so a missing SDK is never silently replaced by a non-functional module. A dummy build exposes __is_dummy__ and emits a RuntimeWarning on import so it can never be mistaken for a real one.